### PR TITLE
Add Binder support

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,8 @@ dependencies:
   - openmmtools
   - openmm
   - tqdm
+  - dill
+  - sqlalchemy
   - openpathsampling
   - openpathsampling-cli
 prefix: /Users/dwhs/miniconda3/envs/mini-tutorials

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,13 @@
+name: mini-tutorials
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - jupyter
+  - nglview
+  - openmmtools
+  - openmm
+  - tqdm
+  - openpathsampling
+  - openpathsampling-cli
+prefix: /Users/dwhs/miniconda3/envs/mini-tutorials


### PR DESCRIPTION
There's a comment in the README that the tutorial works in Binder. In principle, that should be completely possible, but it'll be a lot nicer if there's a button the user can click to launch Binder!

- [x] Set up binder yml file
- [ ] Set up custom JupyterLab workspace
- [ ] Add link for simstore_and_cli tutorial that loads the workspace