### PR TITLE
Add link to simstore_and_cli video 2

### DIFF
--- a/simstore_and_cli/README.md
+++ b/simstore_and_cli/README.md
@@ -17,7 +17,7 @@ This tutorial was presented as a series of three YouTube videos. You can watch
 them in the playlist for this tutorial [COMING SOON], or you can watch each part:
 
 * [Part 1: Setting up with SimStore](https://www.youtube.com/watch?v=IAipZfZpwZ4)
-* COMING SOON: Part 2: Running simulations with the CLI
+* [Running simulations with the CLI](https://www.youtube.com/watch?v=VGN-NfuZGqY)
 * COMING SOON: Part 3: Analyzing the results
 
 ## Requirements

--- a/simstore_and_cli/README.md
+++ b/simstore_and_cli/README.md
@@ -17,7 +17,7 @@ This tutorial was presented as a series of three YouTube videos. You can watch
 them in the playlist for this tutorial [COMING SOON], or you can watch each part:
 
 * [Part 1: Setting up with SimStore](https://www.youtube.com/watch?v=IAipZfZpwZ4)
-* [Running simulations with the CLI](https://www.youtube.com/watch?v=VGN-NfuZGqY)
+* [Part 2: Running simulations with the CLI](https://www.youtube.com/watch?v=VGN-NfuZGqY)
 * COMING SOON: Part 3: Analyzing the results
 
 ## Requirements


### PR DESCRIPTION
This adds a link to the new video (not yet published, but accessible with the link). @sroet -- double check that I uploaded the right thing? (at least it looks like I posted the version with the sync issues fixed)

Also, I was debating between two screenshots as the thumbnail -- let me know if one is preferred.

<img width="1440" alt="thumb1" src="https://user-images.githubusercontent.com/8178546/132566376-2365e8f3-9c7f-4e2d-b447-59ea25ce194a.png">

<img width="1440" alt="thumb2" src="https://user-images.githubusercontent.com/8178546/132566401-902d403e-29f6-4903-aa6b-e460cd2c8a1c.png">
